### PR TITLE
reject attempts to add a note when one already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ chmod u+x ~/.todo.actions.d/note/note
 
 ### Add a Description to a Task
 
-> **IMPORTANT**: `add` a new note into a task which already has a note will effectively ovewrite the existing one. The content of the previous one, however, is kept intact.
+> *Note*: `add`ing a new note into a task which already has a note will fail with an error and no changes.
 
 ```bash
 # Simply a single text

--- a/note.py
+++ b/note.py
@@ -101,6 +101,9 @@ def add_note(task_id: int, note: str) -> None:
     if task is None:
         raise ValueError(f"Task #{task_id} not found in todo.txt")
 
+    if task.note_id is not None:
+        raise ValueError(f"Task #{task_id} already has a note")
+
     note_dir: Path = Path(os.getenv('TODO_DIR')) / 'notes'
 
     if not note_dir.is_dir():


### PR DESCRIPTION
For me, `add`'s current behavior to replace an existing note is a data loss (well, repair) trap. Given that there is also `edit` to replace a note, for me it seemed better to reject `add` if there's already a note. This PR does that.

Thanks for this extension, I like it!